### PR TITLE
Add WordPress PSR-4 autoloader plugin

### DIFF
--- a/WP-README.md
+++ b/WP-README.md
@@ -1,0 +1,19 @@
+# WP FSM Autoloader
+
+This plugin exposes the [winzou/state-machine](https://github.com/winzou/StateMachine) library to WordPress through a simple PSR-4 autoloader. Activate it to make the `SM` namespace available for other plugins.
+
+## Installation
+
+1. Copy this repository into `wp-content/plugins/wp-fsm-autoloader`.
+2. From the plugin directory run `composer install` to fetch required Symfony components.
+3. Activate **WP FSM Autoloader** from the WordPress admin panel.
+
+## Usage
+
+Other plugins can now instantiate and configure state machines using the classes under the `SM` namespace. See `WP-GENERIC-INTEGRATION.md` for a detailed guide on integrating the library with custom post types, REST endpoints and UI elements.
+
+## Developer Notes
+
+- The autoloader maps the `SM\` namespace to `src/SM/`.
+- If Composer is available, `vendor/autoload.php` will be loaded automatically.
+- Ensure dependencies are installed before using the state machine in production.

--- a/wp-fsm-autoloader.php
+++ b/wp-fsm-autoloader.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Plugin Name: WP FSM Autoloader
+ * Description: Provides PSR-4 autoloading for the winzou/state-machine library so other plugins can use it.
+ * Version: 0.1.0
+ * Author: WP FSM
+ * License: MIT
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Load Composer dependencies if available.
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Register autoloader for the SM namespace using PSR-4.
+spl_autoload_register( function ( $class ) {
+    $prefix   = 'SM\\';
+    $base_dir = plugin_dir_path( __FILE__ ) . 'src/SM/';
+
+    $len = strlen( $prefix );
+    if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+        return;
+    }
+
+    $relative_class = substr( $class, $len );
+    $file           = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+
+    if ( file_exists( $file ) ) {
+        require_once $file;
+    }
+} );


### PR DESCRIPTION
## Summary
- add `WP FSM Autoloader` plugin exposing the `SM` namespace in WordPress
- document installation and usage with `WP-README.md`

## Testing
- `php -l wp-fsm-autoloader.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ab916a7f84832e8f2abecc5c34018f