### PR TITLE
Expose factory service and add demo admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,34 @@ Guarding callbacks must return a `bool`. If a guard returns `false`, a transitio
 ##### Credits
 
 This library has been highly inspired by [https://github.com/yohang/Finite](https://github.com/yohang/Finite), but has taken another direction.
+
+WordPress Integration
+----------------------
+
+This repository ships with a helper plugin that exposes the state machine
+factory to WordPress. Activating `wp-fsm-autoloader.php` registers a global
+`wp_fsm_factory()` function. Other plugins may hook the
+`wp_fsm_factory_configs` filter to supply graph configurations before
+requesting a factory instance:
+
+```php
+add_filter( 'wp_fsm_factory_configs', function( $configs ) {
+    $configs[] = array(
+        'class'         => My_Object::class,
+        'graph'         => 'my_graph',
+        'property_path' => 'state',
+        // ... states and transitions
+    );
+    return $configs;
+} );
+
+$factory = wp_fsm_factory();
+$sm      = $factory->get( $object, 'my_graph' );
+```
+
+### Demo Admin Page
+
+A proof‑of‑concept plugin lives in `examples/wp-fsm-poc.php`. When activated it
+adds an **FSM Demo** page under the WordPress admin menu. The page shows the
+current state and lets you trigger transitions using radio buttons with a
+confirmation checkbox.

--- a/WP-README.md
+++ b/WP-README.md
@@ -12,6 +12,33 @@ This plugin exposes the [winzou/state-machine](https://github.com/winzou/StateMa
 
 Other plugins can now instantiate and configure state machines using the classes under the `SM` namespace. See `WP-GENERIC-INTEGRATION.md` for a detailed guide on integrating the library with custom post types, REST endpoints and UI elements.
 
+### Service Function
+
+The plugin exposes a helper function `wp_fsm_factory()` that returns a shared
+`SM\Factory\Factory` instance. Use the `wp_fsm_factory_configs` filter to add
+your own graphs before calling the function:
+
+```php
+add_filter( 'wp_fsm_factory_configs', function( $configs ) {
+    $configs[] = array(
+        'class'         => My_Object::class,
+        'graph'         => 'my_graph',
+        'property_path' => 'state',
+        // states and transitions here
+    );
+    return $configs;
+} );
+
+$factory = wp_fsm_factory();
+$sm      = $factory->get( $object, 'my_graph' );
+```
+
+### Proof of Concept Admin Page
+
+A demonstration plugin lives in `examples/wp-fsm-poc.php`. Activate it alongside
+the autoloader to add an **FSM Demo** page to the WordPress admin, showcasing
+transitions with radio buttons and a confirmation checkbox.
+
 ## Developer Notes
 
 - The autoloader maps the `SM\` namespace to `src/SM/`.

--- a/examples/wp-fsm-poc.php
+++ b/examples/wp-fsm-poc.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Plugin Name: WP FSM Demo
+ * Description: Demonstrates the state machine library with a simple admin page.
+ * Version: 0.1.0
+ * Author: WP FSM
+ * License: MIT
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class WPFSM_Demo_Object {
+    public $state;
+
+    public function __construct( $state = 'start' ) {
+        $this->state = $state;
+    }
+}
+
+// Provide the configuration for our demo object's state machine via the factory filter.
+add_filter( 'wp_fsm_factory_configs', function( $configs ) {
+    $configs[] = array(
+        'class'         => WPFSM_Demo_Object::class,
+        'graph'         => 'demo_graph',
+        'property_path' => 'state',
+        'states'        => array( 'start', 'middle', 'end' ),
+        'transitions'   => array(
+            'to_middle' => array(
+                'from' => array( 'start' ),
+                'to'   => 'middle',
+            ),
+            'to_end' => array(
+                'from' => array( 'middle' ),
+                'to'   => 'end',
+            ),
+            'reset' => array(
+                'from' => array( 'middle', 'end' ),
+                'to'   => 'start',
+            ),
+        ),
+    );
+
+    return $configs;
+} );
+
+// Register the demo admin page.
+add_action( 'admin_menu', function() {
+    add_menu_page( 'FSM Demo', 'FSM Demo', 'manage_options', 'wp-fsm-demo', 'wp_fsm_demo_render' );
+} );
+
+/**
+ * Render the admin demo page.
+ */
+function wp_fsm_demo_render() {
+    $state = get_option( 'wp_fsm_demo_state', 'start' );
+    $obj   = new WPFSM_Demo_Object( $state );
+    $sm    = wp_fsm_factory()->get( $obj, 'demo_graph' );
+
+    if ( isset( $_POST['wp_fsm_demo_nonce'] ) && wp_verify_nonce( $_POST['wp_fsm_demo_nonce'], 'wp_fsm_demo' ) ) {
+        $transition = isset( $_POST['transition'] ) ? sanitize_text_field( wp_unslash( $_POST['transition'] ) ) : '';
+        $confirm    = ! empty( $_POST['confirm'] );
+
+        if ( $confirm && $sm->can( $transition ) ) {
+            $sm->apply( $transition );
+            update_option( 'wp_fsm_demo_state', $obj->state );
+            echo '<div class="updated"><p>Transition applied.</p></div>';
+        } else {
+            echo '<div class="error"><p>Transition blocked.</p></div>';
+        }
+    }
+
+    $state = get_option( 'wp_fsm_demo_state', 'start' );
+    $obj   = new WPFSM_Demo_Object( $state );
+    ?>
+    <div class="wrap">
+        <h1>FSM Demo</h1>
+        <p>Current state: <strong><?php echo esc_html( $obj->state ); ?></strong></p>
+        <form method="post">
+            <?php wp_nonce_field( 'wp_fsm_demo', 'wp_fsm_demo_nonce' ); ?>
+            <p><label><input type="radio" name="transition" value="to_middle"> To Middle</label></p>
+            <p><label><input type="radio" name="transition" value="to_end"> To End</label></p>
+            <p><label><input type="radio" name="transition" value="reset"> Reset</label></p>
+            <p><label><input type="checkbox" name="confirm" value="1"> Confirm transition</label></p>
+            <p><input type="submit" class="button button-primary" value="Apply"></p>
+        </form>
+    </div>
+    <?php
+}

--- a/wp-fsm-autoloader.php
+++ b/wp-fsm-autoloader.php
@@ -33,3 +33,25 @@ spl_autoload_register( function ( $class ) {
         require_once $file;
     }
 } );
+
+// Expose a factory helper so other plugins can easily build state machines.
+if ( ! function_exists( 'wp_fsm_factory' ) ) {
+    /**
+     * Returns a shared instance of the state machine Factory.
+     *
+     * Other plugins can hook the `wp_fsm_factory_configs` filter to provide
+     * graph configurations before the factory is instantiated.
+     *
+     * @return \SM\Factory\Factory
+     */
+    function wp_fsm_factory() {
+        static $factory = null;
+
+        if ( null === $factory ) {
+            $configs = apply_filters( 'wp_fsm_factory_configs', array() );
+            $factory = new \SM\Factory\Factory( $configs );
+        }
+
+        return $factory;
+    }
+}


### PR DESCRIPTION
## Summary
- expose `wp_fsm_factory()` helper to provide a shared state-machine factory for plugins
- document WordPress integration and add demo plugin with admin page to test transitions
- add README instructions for new service function and POC

## Testing
- `php -l wp-fsm-autoloader.php`
- `php -l examples/wp-fsm-poc.php`
- `composer validate`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b0876cfe1c832ead341f8cef6c8f9a