### PR TITLE
Add factory helper and demo admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ The era of hard-coded states is over!
 
 [![Build](https://github.com/winzou/state-machine/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/winzou/state-machine/actions/workflows/build.yml)
 
+WordPress Plugin
+----------------
+
+This repository also ships with a simple WordPress plugin that makes the
+state machine library available to other plugins and includes a demo page to
+experiment with it.
+
+### Service Function
+
+Activate the plugin and call `wp_fsm_factory()` from anywhere in WordPress to
+retrieve a shared `SM\Factory\Factory` instance. Other plugins may register
+their own configurations via `$factory->addConfig( $config )` and obtain state
+machines with `$factory->get( $object, $graph )`.
+
+### Demo Admin Page
+
+After activating the plugin, navigate to **Tools → FSM Demo** in the WordPress
+admin. The page shows the current state and lets you trigger transitions using
+radio buttons and a checkbox. It serves as a basic proof of concept for the
+state machine.
+
 Installation (via composer)
 ---------------
 

--- a/WP-README.md
+++ b/WP-README.md
@@ -10,7 +10,9 @@ This plugin exposes the [winzou/state-machine](https://github.com/winzou/StateMa
 
 ## Usage
 
-Other plugins can now instantiate and configure state machines using the classes under the `SM` namespace. See `WP-GENERIC-INTEGRATION.md` for a detailed guide on integrating the library with custom post types, REST endpoints and UI elements.
+Other plugins can now instantiate and configure state machines using the classes under the `SM` namespace. The helper function `wp_fsm_factory()` returns a shared instance of `SM\Factory\Factory` that can be reused across plugins. See `WP-GENERIC-INTEGRATION.md` for a detailed guide on integrating the library with custom post types, REST endpoints and UI elements.
+
+After activation a small proof-of-concept page is available under **Tools → FSM Demo**. It showcases a simple state machine controlled with radio buttons and a checkbox.
 
 ## Developer Notes
 

--- a/wp-fsm-autoloader.php
+++ b/wp-fsm-autoloader.php
@@ -33,3 +33,129 @@ spl_autoload_register( function ( $class ) {
         require_once $file;
     }
 } );
+
+// -----------------------------------------------------------------------------
+//  Service helper
+// -----------------------------------------------------------------------------
+
+if ( ! function_exists( 'wp_fsm_factory' ) ) {
+    /**
+     * Retrieve a shared State Machine Factory instance.
+     *
+     * Other plugins can call this function to register state machine
+     * configurations and fetch state machines for their objects.
+     *
+     * @return \SM\Factory\Factory
+     */
+    function wp_fsm_factory() {
+        static $factory = null;
+
+        if ( null === $factory ) {
+            $factory = new \SM\Factory\Factory( [] );
+        }
+
+        return $factory;
+    }
+}
+
+// -----------------------------------------------------------------------------
+//  Demo admin page
+// -----------------------------------------------------------------------------
+
+// Simple object used for the demo state machine.
+class WP_FSM_Demo_Object {
+    /** @var string */
+    public $state;
+
+    public function __construct( $state = 'closed' ) {
+        $this->state = $state;
+    }
+}
+
+add_action( 'admin_menu', 'wp_fsm_demo_admin_menu' );
+
+/**
+ * Register the demo page under Tools.
+ */
+function wp_fsm_demo_admin_menu() {
+    add_management_page(
+        __( 'FSM Demo', 'wp-fsm' ),
+        __( 'FSM Demo', 'wp-fsm' ),
+        'manage_options',
+        'wp-fsm-demo',
+        'wp_fsm_demo_page'
+    );
+}
+
+/**
+ * Render the demo admin page with a simple state machine and form controls.
+ */
+function wp_fsm_demo_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $state = get_option( 'wp_fsm_demo_state', 'closed' );
+
+    if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['transition'] ) ) {
+        check_admin_referer( 'wp_fsm_demo' );
+
+        $transition = sanitize_text_field( wp_unslash( $_POST['transition'] ) );
+        $allow      = ! empty( $_POST['allow_guard'] );
+
+        $config = [
+            'class'         => WP_FSM_Demo_Object::class,
+            'graph'         => 'demo',
+            'property_path' => 'state',
+            'states'        => [ 'closed', 'opened' ],
+            'transitions'   => [
+                'open'  => [ 'from' => [ 'closed' ], 'to' => 'opened' ],
+                'close' => [ 'from' => [ 'opened' ], 'to' => 'closed' ],
+            ],
+        ];
+
+        $factory = wp_fsm_factory();
+        $factory->addConfig( $config, 'demo' );
+
+        $object       = new WP_FSM_Demo_Object( $state );
+        $stateMachine = $factory->get( $object, 'demo' );
+
+        if ( $allow && $stateMachine->can( $transition ) ) {
+            $stateMachine->apply( $transition );
+            $state = $object->state;
+            update_option( 'wp_fsm_demo_state', $state );
+
+            echo '<div class="updated"><p>' . esc_html__( 'Transition applied.', 'wp-fsm' ) . '</p></div>';
+        } else {
+            echo '<div class="error"><p>' . esc_html__( 'Transition not allowed.', 'wp-fsm' ) . '</p></div>';
+        }
+    }
+
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'FSM Demo', 'wp-fsm' ); ?></h1>
+        <p><?php echo esc_html__( 'Current State:', 'wp-fsm' ) . ' ' . esc_html( $state ); ?></p>
+        <form method="post">
+            <?php wp_nonce_field( 'wp_fsm_demo' ); ?>
+            <p>
+                <label>
+                    <input type="radio" name="transition" value="open" />
+                    <?php esc_html_e( 'Open', 'wp-fsm' ); ?>
+                </label><br />
+                <label>
+                    <input type="radio" name="transition" value="close" />
+                    <?php esc_html_e( 'Close', 'wp-fsm' ); ?>
+                </label>
+            </p>
+            <p>
+                <label>
+                    <input type="checkbox" name="allow_guard" value="1" />
+                    <?php esc_html_e( 'Allow transition', 'wp-fsm' ); ?>
+                </label>
+            </p>
+            <?php submit_button( __( 'Apply Transition', 'wp-fsm' ) ); ?>
+        </form>
+    </div>
+    <?php
+}
+


### PR DESCRIPTION
## Summary
- provide `wp_fsm_factory()` helper exposing a shared state machine factory
- add a proof-of-concept admin page with radio buttons and a checkbox to exercise a demo state machine
- document usage of the helper and demo page in the README files

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpspec run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68b0875fc244832e84ca962715120fbb